### PR TITLE
Add static async drainer

### DIFF
--- a/Sources/WorkPoolDraning/DynamicAsyncWorkPoolDrainer.swift
+++ b/Sources/WorkPoolDraning/DynamicAsyncWorkPoolDrainer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// `DynamicAsyncWorkPoolDrainer` allow to add work dynamically. Even if atm it was drained, you still can add more work and iterate later over all resutls.
 ///  But if one of tasks failed ot draining was cancelled, no new work will be added
 ///
-/// If drain will be cancelled in the middle of process, it will throw `WorkPoolDrainer.cancelled` in iterator
+/// If drain will be cancelled, it will throw `WorkPoolDrainerError.cancelled` in iterator. This happens even if all current tasks completed
 ///
 /// Usage:
 /// ```
@@ -26,7 +26,7 @@ import Foundation
 /// - note: Adding extra work when iteration is almost completed might lead to undefined iterator behaviour. So better to add all work and start iteration after that.
 ///
 /// Order of iteration might be different from order of added work, because each process might take different amount of time and we prefer to provide result ASAP
-public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sendable, ThreadSafeDrainer {
+public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sendable, ThreadSafeDrainer, WorkPoolDrainer {
 
     public typealias Element = T
 
@@ -60,12 +60,12 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
     public func cancel() {
         internalStateLock.lock()
         defer { internalStateLock.unlock() }
-        self.state = .failed(WorkPoolDrainer.cancelled)
+        self.state = .failed(WorkPoolDrainerError.cancelled)
         self.producers.removeAll()
         let waiters = self.updateWaiters
         self.updateWaiters.removeAll()
         DispatchQueue.global().async {
-            waiters.forEach { $0(.failure(WorkPoolDrainer.cancelled)) }
+            waiters.forEach { $0(.failure(WorkPoolDrainerError.cancelled)) }
         }
     }
 

--- a/Sources/WorkPoolDraning/DynamicAsyncWorkPoolDrainer.swift
+++ b/Sources/WorkPoolDraning/DynamicAsyncWorkPoolDrainer.swift
@@ -7,6 +7,9 @@ import Foundation
 /// ``Swift.TaskGroup`` execute all given tasks simultaniously, so it is not suitable for this scenario
 ///
 /// `DynamicAsyncWorkPoolDrainer` allow to add work dynamically. Even if atm it was drained, you still can add more work and iterate later over all resutls.
+///  But if one of tasks failed ot draining was cancelled, no new work will be added
+///
+/// If drain will be cancelled in the middle of process, it will throw `WorkPoolDrainer.cancelled` in iterator
 ///
 /// Usage:
 /// ```
@@ -51,6 +54,18 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
 
         DispatchQueue.global().async {
             self.checkForAvailableSlot()
+        }
+    }
+
+    public func cancel() {
+        internalStateLock.lock()
+        defer { internalStateLock.unlock() }
+        self.state = .failed(WorkPoolDrainer.cancelled)
+        self.producers.removeAll()
+        let waiters = self.updateWaiters
+        self.updateWaiters.removeAll()
+        DispatchQueue.global().async {
+            waiters.forEach { $0(.failure(WorkPoolDrainer.cancelled)) }
         }
     }
 

--- a/Sources/WorkPoolDraning/StaticAsyncWorkPoolDrainer.swift
+++ b/Sources/WorkPoolDraning/StaticAsyncWorkPoolDrainer.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Executed async process block on predefined stack of elements, limiting number of simultanious executions
+///
+/// In some cases, we need execute many heavy tasks and we want limit number of simultanious executions
+/// ``Swift.TaskGroup`` execute all given tasks simultaniously, so it is not suitable for this scenario
+///
+/// If drain will be cancelled in the middle of process, it will throw `WorkPoolDrainer.cancelled` in iterator
+///
+/// Usage:
+/// ```
+/// let drainer = StaticAsyncWorkPoolDrainer(stack: files, maxConcurrentOperationCount: 5) { file in
+///     // heavy operation on input file
+/// }
+///
+/// for try await processedFile in drainer {
+///     // post-processing
+/// }
+/// ```
+///
+/// - note: Order of iteration might be different from order of input stack, because each process might take different amount of time and we prefer to provide result ASAP
+public final class StaticAsyncWorkPoolDrainer<Input, Output>: AsyncSequence, @unchecked Sendable, ThreadSafeDrainer {
+
+    public typealias Element = Output
+
+    public typealias AsyncIterator = AsyncDrainerIterator<Element>
+
+    public init(stack: some Collection<Input>,
+                maxConcurrentOperationCount: Int,
+                process: @escaping (Input) async throws -> Output) {
+        precondition(maxConcurrentOperationCount > 0)
+        self.pool = DynamicAsyncWorkPoolDrainer(maxConcurrentOperationCount: maxConcurrentOperationCount)
+        for element in stack {
+            pool.add {
+                try await process(element)
+            }
+        }
+    }
+
+    public func cancel() {
+        pool.cancel()
+    }
+
+    // MARK: AsyncSequence
+
+    public func makeAsyncIterator() -> AsyncDrainerIterator<Element> {
+        pool.makeAsyncIterator()
+    }
+
+    // MARK: ThreadSafeDrainer
+
+    var internalStateLock: PosixLock { pool.internalStateLock }
+
+    var state: DrainerState { pool.state }
+
+    var storage: [Output] { pool.storage }
+
+    var updateWaiters: [UpdateWaiter<Output>] {
+        get { pool.updateWaiters }
+        set { pool.updateWaiters = newValue }
+    }
+
+    // MARK: Private
+
+    private let pool: DynamicAsyncWorkPoolDrainer<Output>
+}
+

--- a/Sources/WorkPoolDraning/WorkPoolDrainer.swift
+++ b/Sources/WorkPoolDraning/WorkPoolDrainer.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public enum WorkPoolDrainerError: Error {
+    case cancelled
+}
+
+public protocol WorkPoolDrainer<Element>: AsyncSequence {
+
+    func cancel()
+
+    func collect() async throws -> [Element]
+}
+
+public extension WorkPoolDrainer {
+    func collect() async throws -> [Element] {
+        try await reduce(into: [Element]()) { $0.append($1) }
+    }
+}
+
+public extension WorkPoolDrainer where Element == Void {
+    func wait() async throws {
+        _ = try await collect()
+    }
+}


### PR DESCRIPTION
Following [Proposal](https://github.com/NikolayJuly/drain-work-pool/issues/1):
- Add new class for async processing of predefined stack
- Also added wait and collect methods to all 3 classes