### PR TITLE
Add `closeIntake` for `DynamicAsyncWorkPoolDrainer`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package aim to help with execution of big amount of tasks, but limit number
 ## Overview
 
 Package provides few work pools, depending on knowledge of input tasks beforehand. 
-All work pools in package are `AsyncAequence`, which works on push approach. It means that work will be executed even if no one iterate over it.
+All work pools in package are `AsyncSequence`, which works on push approach. It means that work will be executed even if no one iterate over it.
 
 
 ## How to choose correct work pool?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![swift](https://img.shields.io/badge/Swift-5.7-orange.svg)
+![swift](https://img.shields.io/badge/Swift-5.9-orange.svg)
 
 # WorkPoolDraning
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This package aim to help with execution of big amount of tasks, but limit number
 ## Overview
 
 Package provides few work pools, depending on knowledge of input tasks beforehand. 
-All work pools in package are `AsyncDequence`, which works on push approach. It means that work will be executed even if no one iterate over it.
+All work pools in package are `AsyncAequence`, which works on push approach. It means that work will be executed even if no one iterate over it.
 
 
 ## How to choose correct work pool?
 
 Package contains 2 type of pools: static and dynamic. Dynamic pool allow you to add work tasks while it is executing. 
-Static pool, on the other hand, execute same task on predefined stack of elements.
+Static pool, on the other hand, execute same task on predefined collection of elements.
 
 On top of that, choose which basis you want: DispatchQueue or Structured Concurrency.
 
@@ -24,14 +24,14 @@ Decision tree:
 
 ## Why?
 
-Why do we need these package, if we have TaskGroup?
+Why do we need this package, if we have TaskGroup?
 
 `TaskGroup` do not allow to limit number of simultaneous executions, which is important in some cases:
 
 - Internet bandwidth is limited, no reason to trigger unlimited amount of connections
 - Storage bandwidth is limited, no reason to start thousands of read/write operations at the same time
 - Needs to limit CPU usage, because you need to use mac, while it executes long running tasks in background
-- Define QoS not always enough, as you might want to have more control over number of simultaneous excutions and do not depend on QoS evristics
+- Define QoS not always enough, as you might want to have more control over number of simultaneous executions and do not depend on QoS evristics
 
 
 ## Documentation

--- a/Sources/WorkPoolDraning/DynamicAsyncWorkPoolDrainer.swift
+++ b/Sources/WorkPoolDraning/DynamicAsyncWorkPoolDrainer.swift
@@ -79,7 +79,7 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
         defer { internalStateLock.unlock() }
         isSealed = true
 
-        if producers.isEmpty {
+        if producers.isEmpty, currentRunningOperationsCount == 0 {
             let waiters = self.updateWaiters
             self.updateWaiters.removeAll()
             Task.detached {

--- a/Sources/WorkPoolDraning/DynamicAsyncWorkPoolDrainer.swift
+++ b/Sources/WorkPoolDraning/DynamicAsyncWorkPoolDrainer.swift
@@ -50,7 +50,7 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
             return
         }
 
-        DispatchQueue.global().async {
+        Task.detached {
             self.checkForAvailableSlot()
         }
     }
@@ -68,7 +68,7 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
             return
         }
 
-        DispatchQueue.global().async {
+        Task.detached {
             self.checkForAvailableSlot()
         }
     }
@@ -82,7 +82,7 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
         if producers.isEmpty {
             let waiters = self.updateWaiters
             self.updateWaiters.removeAll()
-            DispatchQueue.global().async {
+            Task.detached {
                 waiters.forEach { $0(.success(nil)) }
             }
             self.state = .completed
@@ -96,7 +96,7 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
         self.producers.removeAll()
         let waiters = self.updateWaiters
         self.updateWaiters.removeAll()
-        DispatchQueue.global().async {
+        Task.detached {
             waiters.forEach { $0(.failure(WorkPoolDrainerError.cancelled)) }
         }
     }
@@ -164,7 +164,7 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
                 self.state = .completed
                 let waiters = self.updateWaiters
                 self.updateWaiters.removeAll()
-                DispatchQueue.global().async {
+                Task.detached {
                     waiters.forEach { $0(.success(nil)) }
                 }
             }
@@ -213,7 +213,7 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
 
             let optionalResult = result.map { $0 as T? }
 
-            DispatchQueue.global().async {
+            Task.detached {
                 waiters.forEach { $0(optionalResult) }
             }
 
@@ -222,7 +222,7 @@ public final class DynamicAsyncWorkPoolDrainer<T>: AsyncSequence, @unchecked Sen
             }
         }
 
-        DispatchQueue.global().async {
+        Task.detached {
             self.checkForAvailableSlot()
         }
     }

--- a/Sources/WorkPoolDraning/WorkPoolDrainer.swift
+++ b/Sources/WorkPoolDraning/WorkPoolDrainer.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum WorkPoolDrainerError: Error {
     case cancelled
+    case poolIntakeAlreadyClosed
 }
 
 public protocol WorkPoolDrainer<Element>: AsyncSequence {

--- a/Sources/WorkPoolDraning/WorkPoolDraning.docc/WorkPoolDraning.md
+++ b/Sources/WorkPoolDraning/WorkPoolDraning.docc/WorkPoolDraning.md
@@ -1,16 +1,17 @@
 # ``WorkPoolDraning``
 
-This package aim to help with execute big amount of tasks, but limit number of simultaneously executed tasks.
+This package aim to help with execution of big amount of tasks, but limit number of simultaneously executed tasks.
 
 ## Overview
 
-All work pools in package are `AsyncDequence`, which works on push approach. It means that work will be executed even if no one iterate over it.
+Package provides few work pools, depending on knowledge of input tasks beforehand. 
+All work pools in package are `AsyncAequence`, which works on push approach. It means that work will be executed even if no one iterate over it.
 
 
 ## How to choose correct work pool?
 
 Package contains 2 type of pools: static and dynamic. Dynamic pool allow you to add work tasks while it is executing. 
-Static pool on other hand execute same task on predefined stack of elements.
+Static pool on other hand execute same task on predefined collection of elements.
 
 On top of that, choose which basis you want: DispatchQueue or Structured Concurrency.
 
@@ -21,14 +22,14 @@ Decision tree:
 
 ## Why?
 
-Why do we need these package, if we have TaskGroup?
+Why do we need this package, if we have TaskGroup?
 
 `TaskGroup` do not allow to limit number of simultaneous executions, which is important in some cases:
 
 - Internet bandwidth is limited, no reason to trigger unlimited amount of connections
 - Storage bandwidth is limited, no reason to start thousands of read/write operations at the same time
 - Needs to limit CPU usage, becase you need to use mac, while it executes long running tasks in background
-- Define QoS not always enough, as you might want to have more control over number of simultaneous excutions and do not depend on QoS evristics
+- Define QoS not always enough, as you might want to have more control over number of simultaneous executions and do not depend on QoS evristics
 
 ## Topics
 

--- a/Sources/WorkPoolDraning/WorkPoolDraning.docc/WorkPoolDraning.md
+++ b/Sources/WorkPoolDraning/WorkPoolDraning.docc/WorkPoolDraning.md
@@ -5,7 +5,7 @@ This package aim to help with execution of big amount of tasks, but limit number
 ## Overview
 
 Package provides few work pools, depending on knowledge of input tasks beforehand. 
-All work pools in package are `AsyncAequence`, which works on push approach. It means that work will be executed even if no one iterate over it.
+All work pools in package are `AsyncSequence`, which works on push approach. It means that work will be executed even if no one iterate over it.
 
 
 ## How to choose correct work pool?

--- a/Tests/WorkPoolDraningTests/DynamicAsyncWorkPoolDrainerTests.swift
+++ b/Tests/WorkPoolDraningTests/DynamicAsyncWorkPoolDrainerTests.swift
@@ -9,7 +9,7 @@ final class DynamicAsyncWorkPoolDrainerTests: XCTestCase {
     func testIntProcessingAndAddWorkDuringDraining() async throws {
         let pool = DynamicAsyncWorkPoolDrainer<Int>(maxConcurrentOperationCount: 20)
         for i in 0..<1024 {
-            pool.add {
+            try pool.add {
                 if Bool.random() {
                     try await Task.sleep(nanoseconds: 500_000)
                 }
@@ -21,7 +21,11 @@ final class DynamicAsyncWorkPoolDrainerTests: XCTestCase {
         for try await i in pool {
             resArray.append(i)
             if i % 128 == 0 {
-                pool.add { 1024 + i/128 }
+                try pool.add { 1024 + i/128 }
+            }
+
+            if i == 1024 {
+                pool.closeIntake()
             }
         }
 

--- a/Tests/WorkPoolDraningTests/DynamicAsyncWorkPoolDrainerTests.swift
+++ b/Tests/WorkPoolDraningTests/DynamicAsyncWorkPoolDrainerTests.swift
@@ -11,7 +11,7 @@ final class DynamicAsyncWorkPoolDrainerTests: XCTestCase {
         for i in 0..<1024 {
             try pool.add {
                 if Bool.random() {
-                    try await Task.sleep(nanoseconds: 500_000)
+                    try await Task.sleep(nanoseconds: 500)
                 }
                 return i
             }
@@ -36,6 +36,40 @@ final class DynamicAsyncWorkPoolDrainerTests: XCTestCase {
         XCTAssertTrue(misteryElements.isEmpty, "We missing some elements in resuslt set. \(misteryElements.count) elements: \(misteryElements)")
 
         XCTAssertEqual(resArray.count, 1033)
+    }
+
+    func testAddMoreWorkAfterCompleteInitialDraining() async throws {
+        let pool = DynamicAsyncWorkPoolDrainer<Int>(maxConcurrentOperationCount: 20)
+        for i in 0..<1024 {
+            try pool.add {
+                if Bool.random() {
+                    try await Task.sleep(nanoseconds: 500)
+                }
+                return i
+            }
+        }
+
+        var resArray = [Int]()
+        for try await i in pool {
+            resArray.append(i)
+
+            if i == 1023 {
+                DispatchQueue.global().asyncAfter(deadline: .now() + .nanoseconds(500)) {
+                    for i in 0..<8 {
+                        try? pool.add { 1024 + i }
+                    }
+                    pool.closeIntake()
+                }
+            }
+        }
+
+        let resSet = Set(resArray)
+
+        let misteryElements = Set(0...1031).symmetricDifference(resSet)
+
+        XCTAssertTrue(misteryElements.isEmpty, "We missing some elements in resuslt set. \(misteryElements.count) elements: \(misteryElements)")
+
+        XCTAssertEqual(resArray.count, 1032)
     }
 }
 

--- a/Tests/WorkPoolDraningTests/StaticAsyncWorkPoolDrainerTests.swift
+++ b/Tests/WorkPoolDraningTests/StaticAsyncWorkPoolDrainerTests.swift
@@ -15,7 +15,6 @@ final class StaticAsyncWorkPoolDrainerTests: XCTestCase {
                 try await Task.sleep(nanoseconds: 500)
             }
             _processIntsArray.mutate { `set` in
-
                 `set`.append(int)
             }
             return int
@@ -42,7 +41,7 @@ final class StaticAsyncWorkPoolDrainerTests: XCTestCase {
         @Atomic var concurrentlyRunning = 0
 
         let drainer = StaticAsyncWorkPoolDrainer<Int, Void>(stack: 0..<1024,
-                                                           maxConcurrentOperationCount: 5) { int in
+                                                            maxConcurrentOperationCount: 5) { int in
             _concurrentlyRunning.mutate { counter in
                 counter += 1
             }


### PR DESCRIPTION
Now user is in full control of when stop adding new work to `DynamicAsyncWorkPoolDrainer` so there is no race condition if we add new work close to full draining. Now `DynamicAsyncWorkPoolDrainer` will wait for more work or claosed intake