### PR TITLE
Add option to return AsyncSequence to continue processing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,15 @@ let package = Package(
             name: "WorkPoolDraning",
             targets: ["WorkPoolDraning"]),
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/vsanthanam/AnyAsyncSequence.git", from: "1.0.0")
+    ],
     targets: [
         .target(
             name: "WorkPoolDraning",
-            dependencies: []),
+            dependencies: [
+                .product(name: "AnyAsyncSequence", package: "AnyAsyncSequence")
+            ]),
         .testTarget(
             name: "WorkPoolDraningTests",
             dependencies: ["WorkPoolDraning"]),

--- a/Sources/WorkPoolDraning/Extensions/AsyncSequenceExtension.swift
+++ b/Sources/WorkPoolDraning/Extensions/AsyncSequenceExtension.swift
@@ -1,21 +1,29 @@
+import AnyAsyncSequence
 import Foundation
 
 public extension AsyncSequence {
+    /// Process items, as they arrive, limiting max concurrent operation count.
+    /// - Returns: AsyncSequence<T>, order might be different form order in source collection.
+    /// - note: `process` might be called not in order of a source sequence.
+    func process<T>(limitingMaxConcurrentOperationCountTo maxConcurrentOperationCount: Int,
+                    process: @escaping (Element) async throws -> T) async throws -> AnyAsyncSequence<T> {
+        let poolDrainer = try await _process(
+            limitingMaxConcurrentOperationCountTo: maxConcurrentOperationCount,
+            process: process
+        )
+
+        return AnyAsyncSequence(poolDrainer)
+    }
+
     /// Process items, as they arrive, limiting max concurrent operation count.
     /// - Returns: Array of results, order might be different form order in source collection.
     /// - note: `process` might be called not in order of a source sequence.
     func process<T>(limitingMaxConcurrentOperationCountTo maxConcurrentOperationCount: Int,
                     process: @escaping (Element) async throws -> T) async throws -> [T] {
-        let poolDrainer = DynamicAsyncWorkPoolDrainer<T>(maxConcurrentOperationCount: maxConcurrentOperationCount)
-
-        for try await element in self {
-            // use '?', because I know that it throw only when we already closed intake
-            try? poolDrainer.add {
-                try await process(element)
-            }
-        }
-
-        poolDrainer.closeIntake()
+        let poolDrainer = try await _process(
+            limitingMaxConcurrentOperationCountTo: maxConcurrentOperationCount,
+            process: process
+        )
 
         return try await poolDrainer.collect()
     }
@@ -34,5 +42,21 @@ public extension AsyncSequence {
         poolDrainer.closeIntake()
 
         try await poolDrainer.wait()
+    }
+
+    private func _process<T>(limitingMaxConcurrentOperationCountTo maxConcurrentOperationCount: Int,
+                             process: @escaping (Element) async throws -> T) async throws -> any WorkPoolDrainer<T> {
+        let poolDrainer = DynamicAsyncWorkPoolDrainer<T>(maxConcurrentOperationCount: maxConcurrentOperationCount)
+
+        for try await element in self {
+            // use '?', because I know that it throw only when we already closed intake
+            try? poolDrainer.add {
+                try await process(element)
+            }
+        }
+
+        poolDrainer.closeIntake()
+
+        return poolDrainer
     }
 }

--- a/Sources/WorkPoolDraning/Extensions/CollectionExtension.swift
+++ b/Sources/WorkPoolDraning/Extensions/CollectionExtension.swift
@@ -1,6 +1,19 @@
+import AnyAsyncSequence
 import Foundation
 
 public extension Collection {
+    /// Process collection.
+    /// - Returns: Array of results, order might be different form order in source collection.
+    /// - note: `process` might be called not in order of a collection.
+    func process<T>(limitingMaxConcurrentOperationCountTo maxConcurrentOperationCount: Int,
+                    process: @escaping (Element) async throws -> T) async throws -> AnyAsyncSequence<T>  {
+        let drainer = StaticAsyncWorkPoolDrainer(stack: self, maxConcurrentOperationCount: maxConcurrentOperationCount) { element in
+            try await process(element)
+        }
+
+        return AnyAsyncSequence(drainer)
+    }
+
     /// Process collection.
     /// - Returns: Array of results, order might be different form order in source collection.
     /// - note: `process` might be called not in order of a collection.


### PR DESCRIPTION
Right now I had to wait processing completion, before continuing process collection with another closure/work. I added option to return AnyAyncSequence, so I return AnyAsyncSequesnce, which will be updated while we processing.

This code might be obsolete with swift 6.